### PR TITLE
NEW: Hazelcast supports near cache

### DIFF
--- a/src/test/java/io/ebean/hazelcast/HzCacheFactoryTest.java
+++ b/src/test/java/io/ebean/hazelcast/HzCacheFactoryTest.java
@@ -3,12 +3,12 @@ package io.ebean.hazelcast;
 import io.ebean.DB;
 import io.ebean.Database;
 import io.ebean.Ebean;
-import io.ebean.EbeanServer;
 import io.ebean.cache.ServerCache;
 import io.ebean.cache.ServerCacheManager;
 import io.ebean.cache.TenantAwareCache;
-import io.ebean.cache.TenantAwareKey;
+import io.ebeaninternal.server.cache.DefaultServerQueryCache;
 import org.example.domain.EAddress;
+import org.example.domain.EConfig;
 import org.example.domain.ECustomer;
 import org.example.domain.EOrder;
 import org.junit.Test;
@@ -94,7 +94,20 @@ public class HzCacheFactoryTest {
     ServerCache beanCache = cacheManager.beanCache(ECustomer.class);
 
     assertThat(beanCache).isInstanceOf(TenantAwareCache.class);
-    assertThat(beanCache.unwrap(HzCache.class)).isInstanceOf(HzCache.class);
+    assertThat(beanCache.unwrap(ServerCache.class)).isInstanceOf(HzCache.class);
+
+    ServerCache queryCache = cacheManager.queryCache(ECustomer.class);
+    assertThat(queryCache).isInstanceOf(TenantAwareCache.class);
+    assertThat(queryCache.unwrap(ServerCache.class)).isInstanceOf(HzCacheFactory.HzQueryCache.class);
+
+    beanCache = cacheManager.beanCache(EConfig.class);
+
+    assertThat(beanCache).isInstanceOf(TenantAwareCache.class);
+    assertThat(beanCache.unwrap(ServerCache.class)).isInstanceOf(HzCacheFactory.HzNearCache.class);
+
+    queryCache = cacheManager.queryCache(EConfig.class);
+    assertThat(queryCache).isInstanceOf(TenantAwareCache.class);
+    assertThat(queryCache.unwrap(ServerCache.class)).isInstanceOf(HzCacheFactory.HzQueryCache.class);
 
 //    Ebean.update(ECustomer.class)
 //      .setRaw("name = 'x'")

--- a/src/test/java/org/example/domain/EConfig.java
+++ b/src/test/java/org/example/domain/EConfig.java
@@ -1,0 +1,19 @@
+package org.example.domain;
+
+import io.ebean.annotation.Cache;
+
+import javax.persistence.Entity;
+
+@Cache(enableQueryCache = true, nearCache = true)
+@Entity
+public class EConfig extends EBase {
+  private boolean option1;
+
+  public boolean isOption1() {
+    return option1;
+  }
+
+  public void setOption1(boolean option1) {
+    this.option1 = option1;
+  }
+}


### PR DESCRIPTION
Hello @rbygrave,

according to documentation https://ebean.io/docs/features/l2cache/
> Ebean L2 bean caches for Redis, Hazelcast and Ignite all have a Near cache option. When this is enabled then there is a local in-process cache that is used and hit first, and then only if there is a miss on the near cache does the request go to the remote Redis | Hazelcast | Ignite cache. 
could you please review this PR:

should Hazelcast support "near cache", but I could not find any code, where this should happen.

(I only found [this](https://github.com/ebean-orm/ebean-hazelcast/blob/1b885b084638f9a097d1a7b155e496e99356a6e2/src/test/java/org/integration/ClientTest.java#L25) in a test, but this makes also no sense, how `@Cache(nearCache=true)` should work)

So, could you check this PR, if this implementation would be acceptable?

I use the same logic for near caches as is already used for query caches

Roland